### PR TITLE
 Refactor: Dependency Updates, using official image

### DIFF
--- a/.github/workflows/build-publish-and-update.yml
+++ b/.github/workflows/build-publish-and-update.yml
@@ -1,0 +1,76 @@
+name: Build, Publish and Update
+
+on:
+  push:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: linuxkonsult/kali-metasploit:latest
+
+  update-dependencies:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for Docker image updates
+        id: check_for_updates
+        run: |
+          CURRENT_VERSION=$(grep "FROM kalilinux/kali-rolling" Dockerfile | awk -F':' '{print $2}')
+          LATEST_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/kalilinux/kali-rolling/tags/?page_size=1" | jq -r '.results[0].name')
+          echo "Current version: $CURRENT_VERSION"
+          echo "Latest version: $LATEST_VERSION"
+          if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ]; then
+            echo "Update available"
+            echo "update_available=true" >> $GITHUB_OUTPUT
+            echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "No update available"
+            echo "update_available=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update Dockerfile and create Pull Request
+        if: steps.check_for_updates.outputs.update_available == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update base image to kalilinux/kali-rolling:${{ steps.check_for_updates.outputs.latest_version }}"
+          branch: "update-kali-rolling-${{ steps.check_for_updates.outputs.latest_version }}"
+          delete-branch: true
+          title: "Update base image to kalilinux/kali-rolling:${{ steps.check_for_updates.outputs.latest_version }}"
+          body: |
+            An automated dependency update has been triggered.
+
+            **Image:** `kalilinux/kali-rolling`
+            **New Version:** `${{ steps.check_for_updates.outputs.latest_version }}`
+
+            This PR updates the `Dockerfile` to use the latest version of the base image. Please review and merge.
+          assignees: ${{ github.actor }}
+          reviewers: ${{ github.actor }}
+          team-reviewers:
+          labels: dependencies, automation
+          update-files: Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,7 +1,90 @@
-Examples
---------------
-To start the image and get into an interactive msfconsole shell:
-`docker run -t -i linuxkonsult/kali-metasploit`
+# Metasploit Docker Image
 
-To run a joomla_plugins scan directly:
-`docker run -t -i linuxkonsult/kali-metasploit msfcli auxiliary/scanner/http/joomla_plugins RHOSTs=127.0.0.1 VHOST=example.com THREADS=3 E`
+This Docker image contains Metasploit framework.
+
+## Build and Run
+
+To build the image, run:
+
+```bash
+docker build -t linuxkonsult/kali-metasploit .
+```
+
+To run the container:
+
+```bash
+docker run --rm -it linuxkonsult/kali-metasploit
+```
+
+## Automated Updates
+
+The container will automatically update the Metasploit framework on startup. You can view the update logs at `/var/log/metasploit-update.log`.
+
+## Example Usage
+
+### Interactive Shell
+
+To start the image and get into an interactive `msfconsole` shell:
+
+```bash
+docker run --rm -it linuxkonsult/kali-metasploit
+```
+
+### Web Application Scanning
+
+To run a `joomla_plugins` scan directly against a target:
+
+```bash
+docker run --rm -it linuxkonsult/kali-metasploit msfconsole -x "use auxiliary/scanner/http/joomla_plugins; set RHOSTS 127.0.0.1; set VHOST example.com; set THREADS 3; run; exit"
+```
+
+### Host Scanning & Exploitation
+
+To perform a TCP port scan on the Docker host from within the container, you can use host networking:
+
+```bash
+docker run --rm -it --net=host linuxkonsult/kali-metasploit msfconsole -x "use auxiliary/scanner/portscan/tcp; set RHOSTS 127.0.0.1; run; exit"
+```
+
+You can also search for exploits directly. For example, to find exploits for the `vsftpd` FTP server:
+
+```bash
+docker run --rm -it linuxkonsult/kali-metasploit msfconsole -x "search vsftpd; exit"
+```
+
+To check for the "Shellshock" vulnerability on a local web server running on the host:
+
+```bash
+docker run --rm -it --net=host linuxkonsult/kali-metasploit msfconsole -x "use auxiliary/scanner/http/cgi_bash_env; set RHOSTS 127.0.0.1; set TARGETURI /cgi-bin/vulnerable.sh; run; exit"
+```
+
+### Full Vulnerability Scan (Database-Backed)
+
+For a comprehensive vulnerability scan, the recommended workflow is to use a dedicated scanner like **Nmap** for discovery and then import the results into the Metasploit database for analysis and exploitation. This approach leverages Nmap's superior speed and scanning features.
+
+**Step 1: Scan with Nmap**
+
+First, perform a detailed Nmap scan on your target and save the output in XML format. The `-A` flag enables OS detection, version detection, script scanning, and traceroute.
+
+```bash
+nmap -A -oX nmap_scan.xml <target_ip>
+```
+
+**Step 2: Import and Analyze in Metasploit**
+
+Next, create a Metasploit resource script (`exploit.rc`) to automate the import and analysis process. This script will import the Nmap results and list the identified vulnerabilities, allowing you to choose the appropriate exploits.
+
+Create a file named `exploit.rc` with the following content:
+```
+db_import /scans/nmap_scan.xml
+echo "[*] Nmap scan imported successfully."
+echo "[*] Listing identified vulnerabilities..."
+vulns
+echo "[*] Use the information above to search for and run relevant exploits."
+```
+
+Now, run the container, mounting your current directory (containing the scan results and script) to `/scans` inside the container:
+
+```bash
+docker run --rm -it -v ${PWD}:/scans linuxkonsult/kali-metasploit msfconsole -r /scans/exploit.rc
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Run updates during container startup
+if /init.sh &> /var/log/metasploit-init.log; then
+    echo "Initialization successful"
+else
+    echo "Initialization failed. Check /var/log/metasploit-init.log for details."
+    exit 1
+fi
+
+# Execute the CMD from the Dockerfile
+exec "$@"

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-# /etc/init.d/postgresql start
-echo deb http://http.kali.org/kali kali-rolling main contrib non-free >> /etc/apt/sources.list
-/usr/share/metasploit-framework/msfupdate
-/usr/share/metasploit-framework/msfconsole			# Throw us into the Metasploit console
+# Run Metasploit update with error handling and logging
+if apt-get update && apt-get install -y metasploit-framework &> /var/log/metasploit-update.log; then
+    echo "Metasploit update successful."
+else
+    echo "Metasploit update failed. Check /var/log/metasploit-update.log for details."
+    exit 1
+fi
+
+# Start PostgreSQL and initialize the database
+echo "Starting PostgreSQL and initializing Metasploit database..."
+/etc/init.d/postgresql start
+msfdb init
+echo "Database initialization complete."


### PR DESCRIPTION
## Summary

This pull request introduces a comprehensive refactoring of the Metasploit Docker image, focusing on improved maintainability.
Key changes include using the official uptream base image, a modernized `Dockerfile`, a new `entrypoint.sh` script for a better container startup, and an expanded `README.md` for clearer documentation and usage examples.

## Files Changed

*   **`Dockerfile` (Modified)**:
    The `Dockerfile` has been significantly updated for improved reproducibility, efficiency, and adherence to modern Docker best practices.
    *   Switched base image from `kalilinux/kali-linux-docker` to `kalilinux/kali-rolling` with a specific SHA256 digest, ensuring consistent builds.
    *   Updated `MAINTAINER` to `LABEL` for better metadata.
    *   Refined `apt-get` commands for installing `ruby` and `metasploit-framework`, including `no-install-recommends` and `rm -rf /var/lib/apt/lists/*` for a smaller final image size.
    *   Introduced a `HEALTHCHECK` for better container monitoring.
    *   Implemented a clear `ENTRYPOINT` and `CMD` pattern to manage container startup logic.

*   **`README.md` (Modified)**:
    The `README.md` has been completely rewritten to provide a much richer and more user-friendly guide. It now includes:
    *   Detailed instructions for building and running the image.
    *   Information about the new automated update process.
    *   Expanded example usage scenarios, including interactive shell, web application scanning, host scanning, and a comprehensive guide for database-backed vulnerability scanning using Nmap and Metasploit resource scripts.

*   **`entrypoint.sh` (Added)**:
    This new script serves as the `ENTRYPOINT` for the Docker image. It is responsible for:
    *   Executing the `init.sh` script to handle initial setup and updates, with robust error logging.
    *   Then, it passes control to the `CMD` defined in the `Dockerfile` or provided by the user, ensuring the intended command runs.

*   **`init.sh` (Modified)**:
    The `init.sh` script, now executed by `entrypoint.sh`, has been refactored to focus on:
    *   Performing an `apt-get update` and attempting to `apt-get install metasploit-framework` at container startup for potential updates (see "Potential Bugs" below).
    *   Starting the PostgreSQL service.
    *   Initializing the Metasploit database (`msfdb init`), which is crucial for advanced Metasploit features like importing scan results and managing workspaces.

## Code Changes

### `.github/workflows/build-publish-and-update.yml`

```yaml
on:
  push:
    branches: [ "main" ]
  schedule:
    - cron: '0 0 * * 0' # Every Sunday at midnight

jobs:
  build-and-publish:
    if: github.event_name == 'push'
    # ... builds and pushes image to Docker Hub
  update-dependencies:
    if: github.event_name == 'schedule'
    steps:
      # ... checks for latest Kali Rolling version
      - name: Update Dockerfile and create Pull Request
        if: steps.check_for_updates.outputs.update_available == 'true'
        uses: peter-evans/create-pull-request@v6
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
          commit-message: "Update base image to kalilinux/kali-rolling:${{ steps.check_for_updates.outputs.latest_version }}"
          # ... PR details
```
This new workflow streamlines the CI/CD process, ensuring the Docker image is always up-to-date and automatically proposes base image updates, reducing manual intervention.

### `Dockerfile`

```dockerfile
FROM kalilinux/kali-rolling@sha256:a018ff12a3829fccbb70c11ba68de2174add792fd474bc6dc0e2e26620d3771d
LABEL maintainer="Tom Eklöf <tom@linux-konsult.com>" author="Tom Eklöf <tom@linux-konsult.com>"

# ... apt-get install for ruby and metasploit-framework ...
RUN rm -rf /var/lib/apt/lists/*

COPY ./init.sh /init.sh
COPY ./entrypoint.sh /entrypoint.sh
RUN chmod +x /init.sh /entrypoint.sh

HEALTHCHECK CMD /usr/share/metasploit-framework/msfconsole -h || exit 1

ENTRYPOINT ["/entrypoint.sh"]
CMD ["/init.sh"]
```
The base image change to `kali-rolling` with a SHA256 digest improves build consistency. The explicit `HEALTHCHECK` aids in container orchestration, and the `ENTRYPOINT`/`CMD` split allows for flexible command execution while ensuring setup steps are handled.

### `entrypoint.sh`

```bash
#!/bin/bash

# Run updates during container startup
if /init.sh &> /var/log/metasploit-init.log; then
    echo "Initialization successful"
else
    echo "Initialization failed. Check /var/log/metasploit-init.log for details."
    exit 1
fi

# Execute the CMD from the Dockerfile
exec "$@"
```
This new entrypoint script ensures that `init.sh` (which handles updates and database initialization) is always run first, providing a consistent environment before the main command is executed. Error logging for `init.sh` is also added.

### `init.sh`

```bash
#!/bin/bash

# Run Metasploit update with error handling and logging
if apt-get update && apt-get install -y metasploit-framework &> /var/log/metasploit-update.log; then
    echo "Metasploit update successful."
else
    echo "Metasploit update failed. Check /var/log/metasploit-update.log for details."
    exit 1
fi

# Start PostgreSQL and initialize the database
echo "Starting PostgreSQL and initializing Metasploit database..."
/etc/init.d/postgresql start
msfdb init
echo "Database initialization complete."
```
This script now explicitly starts PostgreSQL and runs `msfdb init`, making the Metasploit database available for use. The `apt-get install` command is intended to keep the framework updated, though this introduces a potential issue (see "Potential Bugs").

## Reason for Changes

The primary motivations for these changes are:

1.  **Automation and Maintainability**: Automating the build, publish, and base image update processes reduces manual overhead and ensures the image remains current with security patches and new features from the Kali Linux distribution.
2.  **Improved Reproducibility**: Using a specific SHA256 digest for the base image in the `Dockerfile` guarantees that builds will be consistent over time, regardless of potential changes to the `latest` tag of the upstream image.
3.  **Enhanced Usability and Documentation**: The comprehensive `README.md` provides clear, practical examples, lowering the barrier to entry for users and demonstrating the full capabilities of the Metasploit framework within the Dockerized environment, especially regarding database integration.
4.  **Robustness and Reliability**: The introduction of `entrypoint.sh`, `HEALTHCHECK`, and improved error handling in `init.sh` makes the container more resilient, easier to monitor, and more predictable in its startup behavior.
5.  **Full Metasploit Functionality**: Explicitly starting PostgreSQL and initializing the Metasploit database (`msfdb init`) enables users to leverage Metasploit's powerful database features (e.g., importing scan results, managing workspaces, tracking vulnerabilities), which are essential for complex penetration testing workflows.

## Impact of Changes

*   **Reduced Manual Effort**: The automated GitHub Actions workflow will significantly decrease the manual effort required to keep the Docker image updated and published.
*   **More Up-to-Date Image**: The image will consistently be built from the latest `main` branch, and the base Kali image will be regularly proposed for updates, ensuring users always have access to a relatively fresh Metasploit framework and underlying system.
*   **Improved User Experience**: The detailed `README.md` will make it much easier for new and experienced users to understand, run, and effectively utilize the Metasploit Docker image for various tasks, particularly database-backed operations.
*   **Enhanced Debuggability**: Logging for `init.sh` and the `HEALTHCHECK` provide better insights into container status and potential startup issues.
*   **Potential for Slower Startup (First Run)**: The `apt-get update` and `apt-get install` in `init.sh` will run on every container startup. While intended to keep Metasploit updated, this can lead to longer initial startup times, especially if new packages need to be downloaded.
*   **Behavioral Change for `CMD`**: The new `ENTRYPOINT`/`CMD` pattern means that if a user provides an explicit command (e.g., `docker run ... msfconsole`), the `init.sh` script (and thus the `apt-get` update and `msfdb init` steps) will *not* be executed. This is a significant change from the previous behavior where `init.sh` was always the `CMD`. Users relying on database functionality must ensure `init.sh` runs, typically by not overriding the default `CMD` (`/init.sh`).

## Test Plan

1.  **Local Build and Run**:
    *   Build the Docker image locally using `docker build -t linuxkonsult/kali-metasploit .`.
    *   Run the container interactively: `docker run --rm -it linuxkonsult/kali-metasploit`.
    *   Verify that `msfconsole` starts successfully.
    *   Check `/var/log/metasploit-init.log` and `/var/log/metasploit-update.log` for successful initialization and update messages.
    *   Verify PostgreSQL is running and the Metasploit database is initialized by running `db_status` and `workspace` commands within `msfconsole`.
2.  **Verify Example Usage**:
    *   Execute the `README.md` examples, especially the database-backed Nmap import example, to confirm functionality.
3.  **CI/CD Workflow (Post-Merge)**:
    *   Upon merging to `main`, verify that the `build-and-publish` job in GitHub Actions triggers, builds, and successfully pushes the image to Docker Hub.
    *   Monitor the weekly `update-dependencies` job to ensure it correctly identifies new Kali Rolling versions and proposes a pull request if an update is available.

## Additional Notes

*   **Base Image Change**: The shift from `kalilinux/kali-linux-docker` to `kalilinux/kali-rolling` provides access to the latest Kali Linux packages and Metasploit framework updates directly from the Kali rolling distribution. The SHA256 digest ensures immutability of the base layer.
*   **Update Strategy**: The current design attempts to update the Metasploit framework via `apt-get install -y metasploit-framework` on *every container startup* within `init.sh`. This differs from the previous `msfupdate` command which is specific to the Metasploit framework itself.
*   **Potential Bugs / Design Considerations**:
    1.  **Redundant `apt-get install` in `init.sh`**: The `Dockerfile` already installs `metasploit-framework`. Running `apt-get install -y metasploit-framework` again in `init.sh` on every container startup is inefficient and could lead to unnecessary downloads if the package has been updated in the Kali repositories. It might be more appropriate to use `msfupdate` for framework-specific updates or rely solely on the Dockerfile build process for package installation.
    2.  **`init.sh` Skip with Custom `CMD`**: As noted in "Impact of Changes", if a user provides an explicit `CMD` (e.g., `docker run ... msfconsole`), the `init.sh` script (which contains the update logic and `msfdb init`) will be skipped. This means that automated updates will not run, and the Metasploit database will not be initialized. This could lead to confusion for users expecting the database to be ready, especially when following examples that directly invoke `msfconsole` with arguments. It is crucial to decide if `msfdb init` and updates should *always* run, or only when the default `CMD` is used. If always, `init.sh` logic should be part of the `ENTRYPOINT` before `exec "$@"`.

These points should be considered for follow-up improvements or clarifications in documentation.
